### PR TITLE
Creates new migration to add columns to attendances and events table

### DIFF
--- a/db/migrate/20260212174542_add_creator_to_events.rb
+++ b/db/migrate/20260212174542_add_creator_to_events.rb
@@ -1,0 +1,5 @@
+class AddCreatorToEvents < ActiveRecord::Migration[8.1]
+  def change
+    add_reference :events, :creator, null: false, foreign_key: { to_table: :users }
+  end
+end

--- a/db/migrate/20260212174654_add_attendance_refs.rb
+++ b/db/migrate/20260212174654_add_attendance_refs.rb
@@ -1,0 +1,7 @@
+class AddAttendanceRefs < ActiveRecord::Migration[8.1]
+  def change
+    add_reference :attendances, :attendee, null: false, foreign_key: { to_table: :users }, index: true
+    add_reference :attendances, :attended_event, null: false, foreign_key: { to_table: :events }, index: true
+    add_index :attendances, [ :attendee_id, :attended_event_id ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,18 +10,25 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_12_170255) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_12_174654) do
   create_table "attendances", force: :cascade do |t|
+    t.integer "attended_event_id", null: false
+    t.integer "attendee_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["attended_event_id"], name: "index_attendances_on_attended_event_id"
+    t.index ["attendee_id", "attended_event_id"], name: "index_attendances_on_attendee_id_and_attended_event_id", unique: true
+    t.index ["attendee_id"], name: "index_attendances_on_attendee_id"
   end
 
   create_table "events", force: :cascade do |t|
     t.datetime "created_at", null: false
+    t.integer "creator_id", null: false
     t.datetime "event_date"
     t.string "location"
     t.string "name"
     t.datetime "updated_at", null: false
+    t.index ["creator_id"], name: "index_events_on_creator_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -35,4 +42,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_12_170255) do
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
+
+  add_foreign_key "attendances", "events", column: "attended_event_id"
+  add_foreign_key "attendances", "users", column: "attendee_id"
+  add_foreign_key "events", "users", column: "creator_id"
 end


### PR DESCRIPTION
This pull request introduces new associations between the `events`, `attendances`, and `users` tables to better track event creators and attendance. The changes add references and enforce foreign key constraints, improving data integrity and enabling more robust querying of event-related data.

**Database schema enhancements:**

* Added a `creator_id` reference to the `events` table, linking each event to its creator in the `users` table and enforcing a foreign key constraint. [[1]](diffhunk://#diff-673c9d0700ffe5372606106873ca493a34eae5252e960120dfc9cc4e30ef5d31R1-R5) [[2]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3L13-R31) [[3]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3R45-R48)
* Added `attendee_id` and `attended_event_id` references to the `attendances` table, connecting each attendance record to a user and an event, with foreign keys and indexes for efficient querying. [[1]](diffhunk://#diff-5914b17746e89fce6dced86cb88434ff8642b20173c6f8514f93d3e325990964R1-R7) [[2]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3L13-R31) [[3]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3R45-R48)
* Created a unique composite index on `attendee_id` and `attended_event_id` in the `attendances` table to prevent duplicate attendance records for the same user and event. [[1]](diffhunk://#diff-5914b17746e89fce6dced86cb88434ff8642b20173c6f8514f93d3e325990964R1-R7) [[2]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3L13-R31)

**Schema synchronization:**

* Updated `db/schema.rb` to reflect the new columns, indexes, and foreign key constraints added by the migrations. [[1]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3L13-R31) [[2]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3R45-R48)