### PR TITLE
Shows attendees of the event

### DIFF
--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -15,4 +15,6 @@
     <%= f.hidden_field :attended_event_id, value: @event.id %>
     <%= f.submit "Attend This Event" %>
   <% end %>
-<% end %>
+<% end %> 
+
+<h2>Attendees:</h2> <ul> <% @event.attendees.each do |attendee| %> <li><%= attendee.email %> </li> <% end %> </ul>


### PR DESCRIPTION
This pull request adds a new feature to the event show page, allowing users to view a list of attendees for the event.

Event attendee display:

* [`app/views/events/show.html.erb`](diffhunk://#diff-4762449bd030fb46d090146948477da2d4f64633de7f0561094a45b63a5e15fbR19-R20): Added a section that displays the emails of all attendees for the event.