### PR TITLE
Separates events between past and upcoming on show user's event page

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,8 +1,17 @@
-<h1> All Events Attended </h1>
+<h1> All Events </h1>
+<h2> Upcoming Events </h2>
 <ul>
-  <% @user.attended_events.each do |event| %>
+  <% @user.attended_events.where("event_date >= ?", Date.today).each do |event| %>
     <li><%= event.name %></li>
   <% end %>
+</ul>
+
+
+<h2> Past Events </h2>
+<ul>
+ <% @user.attended_events.where("event_date < ?", Date.today).each do |event| %>
+    <li><%= event.name %></li>
+ <% end %>
 </ul>
 
 <%= button_to "Logout", destroy_user_session_path, method: :delete %>


### PR DESCRIPTION
This pull request updates the user's profile page to improve how attended events are displayed. Instead of showing all events in a single list, events are now separated into "Upcoming Events" and "Past Events" sections based on their dates.

Event display improvements:

* The heading was changed from "All Events Attended" to "All Events" for clarity.
* The attended events are now split into two lists: "Upcoming Events" (events with a date on or after today) and "Past Events" (events with a date before today), making it easier for users to distinguish between future and previous events.