### PR TITLE
Makes events private , adds invitation option

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -280,6 +280,15 @@ form[action*="/users"] textarea {
 .muted {
 	color: var(--muted-700);
 }
+.invitations-section h2, .invitations-section p{
+  margin: 1.5rem 0 0.75rem 0;
+  font-size: 2 rem;
+  text-align: center;
+}
+.invitations-section .form-submit-btn{
+  display: block;
+  margin: 1rem auto 0 auto;
+}
 
 /* Responsive adjustments: mobile-first then scale up */
 @media (max-width: 479px) {

--- a/app/controllers/attendances_controller.rb
+++ b/app/controllers/attendances_controller.rb
@@ -1,5 +1,7 @@
 class AttendancesController < ApplicationController
   before_action :authenticate_user!
+  before_action :set_event, only: [ :create ]
+  before_action :authorize_event_access, only: [ :create ]
 
   def create
     @attendance = current_user.attendances.build(attendance_params)
@@ -11,7 +13,24 @@ class AttendancesController < ApplicationController
     end
   end
 
+  # TODO: add a destroy action so users can unattend events by adding a cancel attendance button on the event show page that only appears if the user is already marked as attending the event. This destroy action should find the attendance by the current_user and the event id and then destroy that attendance record.
+
   private
+
+  def set_event
+    @event = Event.find(params[:attendance][:attended_event_id])
+  end
+
+  def authorize_event_access
+    unless can_access_event?(@event)
+      redirect_to events_path, alert: "You don't have access to this event."
+    end
+  end
+
+  def can_access_event?(event)
+    event.creator == current_user || event.invited_users.include?(current_user)
+  end
+
   def attendance_params
     params.require(:attendance).permit(:attended_event_id)
   end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,12 +1,17 @@
 class EventsController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_event, only: [ :show ]
+  before_action :set_event, only: [ :show, :destroy ]
+  before_action :authorize_accessing_event, only: [ :show ]
 
   def index
     @events = Event.all.order(event_date: :asc)
   end
 
   def show
+    # Get all users except creator and already invited users
+    @available_users = User.where.not(id: @event.creator_id)
+                           .where.not(id: @event.invited_users.pluck(:id))
+                           .order(:email)
   end
 
   def new
@@ -24,11 +29,33 @@ class EventsController < ApplicationController
     end
   end
 
+  def update
+  end
 
+  def destroy
+    if @event.creator == current_user
+      @event.destroy
+      redirect_to events_path, notice: "Event was successfully deleted."
+    end
+  end
+
+  # TODO: add the ability to make events private and only invited users can register to attend.
+  # the event creator can invite users to attend by clicking an invite button on the event show page that prompts them to add a user by selecting a user from  a dropdown list of all users.
+  # When the event creator invites a user to attend an event, it should allow the event to show up on their events index page and allow them to click on the event to mark themselves as attending.
 
   private
   def set_event
     @event = Event.find(params[:id])
+  end
+
+  def authorize_accessing_event
+    unless access_allowed?(@event)
+      redirect_to events_path, alert: "You are not authorized to view this event."
+    end
+  end
+
+  def access_allowed?(event)
+     event.creator == current_user || event.invited_users.include?(current_user)
   end
 
   def event_params

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -1,0 +1,41 @@
+class InvitationsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_event
+  before_action :authorize_event_creator, only: [ :create, :destroy ]
+
+  def create
+    @user = User.find(params[:user_id])
+
+    # Prevent creator from inviting themselves
+    if @user == current_user
+      redirect_to @event, alert: "You cannot invite yourself to your own event."
+      return
+    end
+
+    @invitation = @event.invitations.build(user: @user)
+
+    if @invitation.save
+      redirect_to @event, notice: "#{@user.email} has been invited to the event."
+    else
+      redirect_to @event, alert: "Unable to invite user. They may already be invited."
+    end
+  end
+
+  def destroy
+    @invitation = @event.invitations.find(params[:id])
+    @invitation.destroy
+    redirect_to @event, notice: "Invitation has been removed."
+  end
+
+  private
+
+  def set_event
+    @event = Event.find(params[:event_id])
+  end
+
+  def authorize_event_creator
+    unless @event.creator == current_user
+      redirect_to events_path, alert: "Only the event creator can manage invitations."
+    end
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,6 +3,11 @@ class UsersController < ApplicationController
   before_action :set_user, only: [ :show ]
 
   def show
+    # Get events user created or is invited to
+    @accessible_events = Event.left_joins(:invitations)
+                              .where("events.creator_id = ? OR invitations.user_id = ?",
+                                     current_user.id, current_user.id)
+                              .distinct
   end
 
   private

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -2,6 +2,8 @@ class Event < ApplicationRecord
   belongs_to :creator, class_name: "User", foreign_key: "creator_id"
   has_many :attendances, foreign_key: "attended_event_id", dependent: :destroy
   has_many :attendees, through: :attendances, source: :attendee
+  has_many :invitations, dependent: :destroy
+  has_many :invited_users, through: :invitations, source: :user
 
   scope :past, -> { where("event_date < ?", Date.today && Time.now) }
   scope :upcoming, -> { where("event_date >= ?", Date.today && Time.now) }

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -1,0 +1,6 @@
+class Invitation < ApplicationRecord
+  belongs_to :event
+  belongs_to :user
+  has_one :attendance, through: :event
+  validates :status, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,6 @@ class User < ApplicationRecord
   has_many :created_events, class_name: "Event", foreign_key: "creator_id", dependent: :destroy
   has_many :attendances, foreign_key: "attendee_id", dependent: :destroy
   has_many :attended_events, through: :attendances, source: :attended_event
+  has_many :invitations, dependent: :destroy
+  has_many :invited_events, through: :invitations, source: :event
 end

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -21,6 +21,52 @@
   <% end %>
 </div>
 
+<% if user_signed_in? && @event.creator == current_user %>
+  <section class="invitations-section" aria-label="Manage Invitations" style="margin-top: 2rem;">
+    <h2>Invite Users</h2>
+    
+    <% if @available_users&.any? %>
+      <div class="form-actions">
+        <%= form_with url: event_invitations_path(@event), method: :post, local: true, html: { role: 'form', 'aria-label': 'Invite user form' } do |f| %>
+          <div class="form-group">
+            <%= f.label :user_id, "Select a user to invite:", class: "form-label" %>
+            <%= f.select :user_id, 
+                options_from_collection_for_select(@available_users, :id, :email), 
+                { prompt: 'Choose a user...' },
+                { class: "form-input", required: true } %>
+          </div>
+          <%= f.submit "Send Invitation", class: "form-submit-btn" %>
+        <% end %>
+      </div>
+    <% else %>
+      <p class="muted">All users have been invited to this event.</p>
+    <% end %>
+
+    <% if @event.invited_users.any? %>
+      <h3 style="margin-top: 2rem;">Invited Users</h3>
+      <div class="invited-users-list">
+        <% @event.invitations.includes(:user).each do |invitation| %>
+          <div class="attendee-item" role="listitem" style="display: flex; justify-content: space-between; align-items: center;">
+            <div style="display: flex; align-items: center;">
+              <div class="attendee-avatar" aria-hidden="true"><%= invitation.user.email[0].upcase %></div>
+              <div class="attendee-info">
+                <div class="attendee-name"><%= invitation.user.email %></div>
+              </div>
+            </div>
+            <%= button_to "Remove", event_invitation_path(@event, invitation), 
+                method: :delete, 
+                data: { confirm: "Are you sure you want to remove this invitation?" },
+                class: "btn-secondary",
+                style: "padding: 0.5rem 1rem; font-size: 0.9rem;" %>
+          </div>
+        <% end %>
+      </div>
+    <% else %>
+      <p class="muted" style="margin-top: 1rem;">No users invited yet.</p>
+    <% end %>
+  </section>
+<% end %>
+
 <section class="attendees-list" aria-label="Attendees">
   <h2>Attendees</h2>
   <% if @event.attendees.any? %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -2,7 +2,7 @@
 
 <h2>Upcoming Events</h2>
 <section class="events-grid" aria-label="Your upcoming events">
-  <% @user.attended_events.where("event_date >= ?", Date.today).each do |event| %>
+  <% @accessible_events.where("event_date >= ?", Date.today).each do |event| %>
     <article class="event-card" aria-labelledby="user-event-<%= event.id %>-title">
       <div class="event-date-badge" aria-hidden="true"><span class="badge-month"><%= event.event_date.strftime("%b") %></span><span class="badge-day"><%= event.event_date.strftime("%d") %></span></div>
       <div class="event-card-body">
@@ -16,7 +16,7 @@
 
 <h2>Past Events</h2>
 <section class="events-grid" aria-label="Your past events">
-  <% @user.attended_events.where("event_date < ?", Date.today).each do |event| %>
+  <% @accessible_events.where("event_date < ?", Date.today).each do |event| %>
     <article class="event-card" aria-labelledby="user-event-<%= event.id %>-title">
       <div class="event-date-badge" aria-hidden="true"><span class="badge-month"><%= event.event_date.strftime("%b") %></span><span class="badge-day"><%= event.event_date.strftime("%d") %></span></div>
       <div class="event-card-body">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,9 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   root "events#index"
 
-  resources :events, only: [ :index, :show, :new, :create ]
+  resources :events, only: [ :index, :show, :new, :create, :update, :destroy ] do
+    resources :invitations, only: [ :create, :destroy ]
+  end
   resources :attendances, only: [ :create ]
   resources :users, only: [ :show ]
 end

--- a/db/migrate/20260222171213_create_invitation.rb
+++ b/db/migrate/20260222171213_create_invitation.rb
@@ -1,0 +1,11 @@
+class CreateInvitation < ActiveRecord::Migration[8.1]
+  def change
+    create_table :invitations do |t|
+      t.references :event, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+      t.string :status, null: false, default: "pending"
+      t.timestamps
+    end
+    add_index :invitations, [ :event_id, :user_id ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_12_174654) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_22_171213) do
   create_table "attendances", force: :cascade do |t|
     t.integer "attended_event_id", null: false
     t.integer "attendee_id", null: false
@@ -31,6 +31,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_12_174654) do
     t.index ["creator_id"], name: "index_events_on_creator_id"
   end
 
+  create_table "invitations", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "event_id", null: false
+    t.string "status", default: "pending", null: false
+    t.datetime "updated_at", null: false
+    t.integer "user_id", null: false
+    t.index ["event_id", "user_id"], name: "index_invitations_on_event_id_and_user_id", unique: true
+    t.index ["event_id"], name: "index_invitations_on_event_id"
+    t.index ["user_id"], name: "index_invitations_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "email", default: "", null: false
@@ -46,4 +57,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_12_174654) do
   add_foreign_key "attendances", "events", column: "attended_event_id"
   add_foreign_key "attendances", "users", column: "attendee_id"
   add_foreign_key "events", "users", column: "creator_id"
+  add_foreign_key "invitations", "events"
+  add_foreign_key "invitations", "users"
 end

--- a/test/fixtures/invitations.yml
+++ b/test/fixtures/invitations.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/invitation_test.rb
+++ b/test/models/invitation_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class InvitationTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
This pull request introduces a full event invitation system, allowing event creators to invite users to events, manage invitations, and restrict event access to only creators and invited users. It includes new models, controllers, database migrations, UI updates, and authorization logic to support these features.

**Event Invitation System**

- Added an `Invitation` model and database table, linking events and users with a status and enforcing uniqueness per event-user pair. [[1]](diffhunk://#diff-c899291de1875b0c2483c0f132ed4503e6c33be63148d6e5d1f4235bfeb1c331R1-R6) [[2]](diffhunk://#diff-f1bc1e2b19e2933bb213f57819937ea3bf0f1d9de7590260835e6dd2dbd8e35eR1-R11) [[3]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3L13-R13) [[4]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3R34-R44) [[5]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3R60-R61)
- Updated the `Event` and `User` models to establish `has_many :invitations` and related associations for invited users and events. [[1]](diffhunk://#diff-716ef9c1cac9e66383f5c4d8a13df148b3b8487421f4bce8e82a367507d5c2edR5-R6) [[2]](diffhunk://#diff-9802ca3c9c4cf89904fd44bc114e35ebdf2c5dd3d5b645491e2b253e1afef29bR10-R11)

**Controllers and Authorization**

- Added an `InvitationsController` for creating and removing invitations, with authorization to ensure only event creators can manage invitations.
- Updated `EventsController` and `AttendancesController` to restrict event access and attendance to creators and invited users, and to provide user lists for inviting. [[1]](diffhunk://#diff-e5ba780d6ceaadee8d430a3b77cd3d401a7f0aeacec1ee78d7aa073f027af8c8L3-R14) [[2]](diffhunk://#diff-e5ba780d6ceaadee8d430a3b77cd3d401a7f0aeacec1ee78d7aa073f027af8c8R32-R60) [[3]](diffhunk://#diff-04c45415df844e47397d39529eda1df896aae94f767a0af5b37947619533be6dR3-R4) [[4]](diffhunk://#diff-04c45415df844e47397d39529eda1df896aae94f767a0af5b37947619533be6dR16-R33)
- Modified `UsersController` to show events the user created or is invited to, not just those attended.

**Views and UI**

- Updated the event show page to allow creators to invite users via a dropdown, display invited users, and remove invitations.
- Updated the user show page to show all accessible events (created or invited), not just attended events. [[1]](diffhunk://#diff-78ff736409d758722403cce31873ba803b3fb526d37398ca21caa557b54dfd95L5-R5) [[2]](diffhunk://#diff-78ff736409d758722403cce31873ba803b3fb526d37398ca21caa557b54dfd95L19-R19)
- Added CSS for the invitations section for better UI presentation.

**Routing and Testing**

- Updated routes to nest invitations under events and support destroying events.
- Added basic invitation fixtures and a test file scaffold. [[1]](diffhunk://#diff-e81e20110f4dccfbe18b983bab708e28021f42c062b2aa6cf4da01579baed7abR1-R11) [[2]](diffhunk://#diff-53d19fb640863a0fae94492b91fa8a2fea237854d0ef348604eb50f3c40a38c2R1-R7)