### PR TITLE
Adds a toaster like message to the flash

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -289,6 +289,29 @@ form[action*="/users"] textarea {
   display: block;
   margin: 1rem auto 0 auto;
 }
+#toast-container {
+  position: fixed;
+  top: 20px;
+  right: 20px;
+  z-index: 9999;
+}
+
+.toast {
+  background: #333;
+  color: white;
+  padding: 12px 16px;
+  margin-bottom: 10px;
+  border-radius: 6px;
+  opacity: 1;
+  transition: opacity 0.3s ease;
+}
+
+.toast.notice { background: #4caf50; }
+.toast.alert { background: #f44336; }
+
+.toast.fade-out {
+  opacity: 0;
+}
 
 /* Responsive adjustments: mobile-first then scale up */
 @media (max-width: 479px) {

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -64,7 +64,7 @@ class EventsController < ApplicationController
 
   def authorize_accessing_event
     unless access_allowed?(@event)
-      redirect_to events_path, alert: "You are not authorized to view this event."
+      redirect_back fallback_location: events_path, alert: "You are not authorized to view this event."
     end
   end
 

--- a/app/javascript/controllers/toast_controller.js
+++ b/app/javascript/controllers/toast_controller.js
@@ -1,0 +1,14 @@
+// app/javascript/controllers/toast_controller.js
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  connect() {
+    setTimeout(() => {
+      this.element.classList.add("fade-out");
+
+      setTimeout(() => {
+        this.element.remove();
+      }, 300);
+    }, 3000); // disappears after 3 seconds
+  }
+}

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,3 +1,10 @@
+<div id="toast-container">
+  <% flash.each do |type, message| %>
+    <div class="toast <%= type %>" data-controller="toast">
+      <%= message %>
+    </div>
+  <% end %>
+</div>
 <h1>All Events</h1>
 
 <div  style="display:flex; justify-content:flex-end; margin-top:1rem;">

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,8 +1,10 @@
-<% flash.each do |type, msg| %>
-  <div>
-    <%= msg %>
-  </div>
-<% end %>
+<div id="toast-container">
+  <% flash.each do |type, message| %>
+    <div class="toast <%= type %>" data-controller="toast">
+      <%= message %>
+    </div>
+  <% end %>
+</div>
 
 <div class="event-details-panel" role="region" aria-label="Event details">
   <% if user_signed_in? && @event.creator == current_user %>


### PR DESCRIPTION
This pull request introduces a new toast notification system for displaying flash messages in the events views, replacing the previous inline flash message display. It also improves the user experience by making authorization errors redirect back to the previous page when possible. The most important changes are grouped below.

**Toast Notification System:**

* Added a new `toast_controller.js` Stimulus controller to handle the automatic fading and removal of toast messages after three seconds.
* Updated the flash message display in `events/index.html.erb` and `events/show.html.erb` to use a new `#toast-container` with styled toast messages, each managed by the new controller. [[1]](diffhunk://#diff-3ae5624c8ddb8424c4be9ab864858ce717f2a357523de1cc7722ec2cf050a401R1-R7) [[2]](diffhunk://#diff-4762449bd030fb46d090146948477da2d4f64633de7f0561094a45b63a5e15fbL1-R7)
* Added new CSS styles in `application.css` for the toast container and toast messages, including color variants for notices and alerts, and fade-out transitions.

**Authorization Handling:**

* Changed the `authorize_accessing_event` method in `events_controller.rb` to redirect users back to their previous page (with a fallback) when they are not authorized, instead of always redirecting to the events index.