### PR TITLE
Fixes invited users styling to match attendees

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -247,7 +247,7 @@ form[action*="/users"] textarea {
 	margin-left: 0.35rem;
 	font-weight: 600;
 }
-.attendees-list {
+.attendees-list, .invitations-section {
 	max-width: 680px;
 	margin: 1rem auto 2rem auto;
 	display: grid;
@@ -279,6 +279,10 @@ form[action*="/users"] textarea {
 }
 .muted {
 	color: var(--muted-700);
+}
+.invitations-section {
+  max-width: 680px;
+  margin: 1rem auto 2rem auto;
 }
 .invitations-section h2, .invitations-section p{
   margin: 1.5rem 0 0.75rem 0;
@@ -358,7 +362,7 @@ form[action*="/users"] textarea {
 	.event-date-badge .badge-day { font-size: 1.05rem; }
 
 	/* Attendee list compact */
-	.attendees-list { margin: 0.5rem 0.75rem; }
+	.attendees-list, .invited-users-list { margin: 0.5rem 0.75rem; }
 	.attendee-item { padding: 0.5rem; }
 	.attendee-avatar { width: 40px; height: 40px; }
 }

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -39,7 +39,7 @@
 </div>
 
 <% if user_signed_in? && @event.creator == current_user %>
-  <section class="invitations-section" aria-label="Manage Invitations" style="margin-top: 2rem;">
+  <section class="invitations-section"  style="margin-top: 2rem;">
     <% if @available_users&.any? %>
       <div class="form-actions">
         <%= form_with url: event_invitations_path(@event), method: :post, local: true, html: { role: 'form', 'aria-label': 'Invite user form' } do |f| %>
@@ -58,21 +58,22 @@
     <% end %>
 
     <% if @event.invited_users.any? %>
-      <h3 style="margin-top: 2rem;">Invited Users</h3>
+      <h2 style="margin-top: 2rem; text-align: left;">Invited Users</h2>
       <div class="invited-users-list">
         <% @event.invitations.includes(:user).each do |invitation| %>
-          <div class="attendee-item" role="listitem" style="display: flex; justify-content: space-between; align-items: center;">
-            <div style="display: flex; align-items: center;">
-              <div class="attendee-avatar" aria-hidden="true"><%= invitation.user.email[0].upcase %></div>
+          <div class="attendee-item" role="listitem" aria-label="Invited User" style="display: flex; ">
+            
+              <div class="attendee-avatar" aria-hidden="true"> <%= invitation.user.email[0].upcase %></div>
               <div class="attendee-info">
                 <div class="attendee-name"><%= invitation.user.email %></div>
               </div>
-            </div>
+            <div style="margin-left: auto;">
             <%= button_to "Remove", event_invitation_path(@event, invitation), 
                 method: :delete, 
                 data: { confirm: "Are you sure you want to remove this invitation?" },
                 class: "btn-secondary",
-                style: "padding: 0.5rem 1rem; font-size: 0.9rem;" %>
+                style: "padding: 0.5rem 1rem; font-size: 0.9rem; " %>
+                </div>
           </div>
         <% end %>
       </div>
@@ -87,7 +88,7 @@
   <% if @event.attendees.any? %>
     <% @event.attendees.each do |attendee| %>
       <div class="attendee-item" role="listitem" aria-label="Attendee">
-        <div class="attendee-avatar" aria-hidden="true"><%= attendee.email[0].upcase %></div>
+        <div class="attendee-avatar" aria-hidden="true"> <%= attendee.email[0].upcase %></div>
         <div class="attendee-info">
           <div class="attendee-name"><%= attendee.email %></div>
         </div>


### PR DESCRIPTION
This pull request refines the UI for the event invitation management section, improving the styling and accessibility of the invited users list. The changes focus on enhancing the layout consistency, visual hierarchy, and accessibility for users managing event invitations.

**Styling and Layout Enhancements:**

* Unified the styling of `.attendees-list` and `.invitations-section` by applying shared layout properties, ensuring consistent appearance across attendee and invitation lists.
* Added `.invited-users-list` to the compact styling rules, so invited users display with the same spacing as attendees.
* Improved the heading for the invited users section by changing `<h3>` to `<h2>` and aligning the text to the left for better visual hierarchy.

**Accessibility Improvements:**

* Added `aria-label="Invited User"` to each invited user item for clearer screen reader navigation.
* Removed redundant ARIA label on the invitation management section, as the heading now provides sufficient context.

**Code Cleanup:**

* Simplified the structure of the invited user item by removing unnecessary nested flex containers and improving spacing for the remove button.