### PR TITLE
Adds the ability for users to cancel their attendance and creator is …

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,17 @@ Visit `http://localhost:3000` and sign up for an account to start creating event
 ## Features
 
 - Users can create multiple events.
-- Users can attend events.
+- Users can attend events they've created or events they've been invited to.
+- A user can invite other users to their events.
+- A user can only see events they have created or events they are attending.
+- A user can rescind an invitation they have sent to another user.
+- A user can edit or delete an event they have created.
 - An event has multiple attendees.
 - An event has a date and a location displayed as a string.
 - Authentication system for users to sign up and log in using Devise.
 
 ## Important Dependencies
 
-TBC
+- Devise – Used for user authentication and management.
+- RSpec – Used for testing the application.
+- Stymulus – Used for styling the application.

--- a/app/controllers/attendances_controller.rb
+++ b/app/controllers/attendances_controller.rb
@@ -1,7 +1,9 @@
 class AttendancesController < ApplicationController
   before_action :authenticate_user!
   before_action :set_event, only: [ :create ]
+  before_action :set_attendance, only: [ :destroy ]
   before_action :authorize_event_access, only: [ :create ]
+  before_action :authorize_attendance_cancellation, only: [ :destroy ]
 
   def create
     @attendance = current_user.attendances.build(attendance_params)
@@ -13,7 +15,11 @@ class AttendancesController < ApplicationController
     end
   end
 
-  # TODO: add a destroy action so users can unattend events by adding a cancel attendance button on the event show page that only appears if the user is already marked as attending the event. This destroy action should find the attendance by the current_user and the event id and then destroy that attendance record.
+  def destroy
+    event = @attendance.attended_event
+    @attendance.destroy
+    redirect_to event_path(event), notice: "You've successfully cancelled your attendance."
+  end
 
   private
 
@@ -21,9 +27,19 @@ class AttendancesController < ApplicationController
     @event = Event.find(params[:attendance][:attended_event_id])
   end
 
+  def set_attendance
+    @attendance = current_user.attendances.find(params[:id])
+  end
+
   def authorize_event_access
     unless can_access_event?(@event)
       redirect_to events_path, alert: "You don't have access to this event."
+    end
+  end
+
+  def authorize_attendance_cancellation
+    if @attendance.attended_event.creator == current_user
+      redirect_back fallback_location: events_path, alert: "Event creators cannot cancel their attendance."
     end
   end
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -5,6 +5,14 @@ class Event < ApplicationRecord
   has_many :invitations, dependent: :destroy
   has_many :invited_users, through: :invitations, source: :user
 
+  after_create :add_creator_as_attendee
+
   scope :past, -> { where("event_date < ?", Date.today && Time.now) }
   scope :upcoming, -> { where("event_date >= ?", Date.today && Time.now) }
+
+  private
+
+  def add_creator_as_attendee
+    attendances.create(attendee: creator)
+  end
 end

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -28,7 +28,7 @@
   <p class="detail-line"><strong>Date:</strong> <span class="detail-value"><%= @event.event_date.strftime("%B %d, %Y %H:%M") %></span></p>
   <p class="detail-line"><strong>Created by:</strong> <span class="detail-value"><%= @event.creator.email %></span></p>
 
-  <% if user_signed_in? && !current_user.attended_events.exists?(@event.id) %>
+  <% if user_signed_in? && !current_user.attended_events.exists?(@event.id) && @event.creator != current_user %>
     <div class="form-actions" style="justify-content:center; margin-top:1rem;">
       <%= form_with model: Attendance.new, url: attendances_path, local: true, html: { role: 'form', 'aria-label': 'Attend event form' } do |f| %>
         <%= f.hidden_field :attended_event_id, value: @event.id %>
@@ -36,7 +36,16 @@
       <% end %>
     </div>
   <% end %>
-</div>
+  <% if user_signed_in? && current_user.attended_events.exists?(@event.id) && @event.creator != current_user %>
+    <div class="form-actions" style="justify-content:center; margin-top:1rem;">
+      <%= button_to "Cancel My Attendance", attendance_path(current_user.attendances.find_by(attended_event_id: @event.id)), 
+          method: :delete, 
+          data: { confirm: "Are you sure you want to cancel your attendance?" },
+          class: "btn-secondary",
+          style: "padding: 0.5rem 1rem; font-size: 0.9rem;" %>
+    </div>
+  <% end%>
+
 
 <% if user_signed_in? && @event.creator == current_user %>
   <section class="invitations-section"  style="margin-top: 2rem;">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,6 @@ Rails.application.routes.draw do
   resources :events, only: [ :index, :show, :new, :create, :edit, :update, :destroy ] do
     resources :invitations, only: [ :create, :destroy ]
   end
-  resources :attendances, only: [ :create ]
+  resources :attendances, only: [ :create, :destroy ]
   resources :users, only: [ :show ]
 end


### PR DESCRIPTION
This pull request introduces the ability for users to cancel their attendance at events they are attending (except for events they have created themselves), and updates the event display and documentation to reflect this new functionality. It also ensures that event creators are automatically marked as attendees of their own events. Below are the most important changes grouped by theme:

### Attendance Management Enhancements

* Added a `destroy` action to the `AttendancesController` to allow users to cancel their attendance at events, with authorization checks to prevent event creators from cancelling their own attendance. Supporting private methods were added for finding the relevant attendance and enforcing these rules. [[1]](diffhunk://#diff-04c45415df844e47397d39529eda1df896aae94f767a0af5b37947619533be6dR4-R6) [[2]](diffhunk://#diff-04c45415df844e47397d39529eda1df896aae94f767a0af5b37947619533be6dL16-R45)
* Updated routes in `routes.rb` to support the new `destroy` action for attendances.
* Modified the event show page (`events/show.html.erb`) to display a "Cancel My Attendance" button for users who are attending an event they did not create, and to hide the "Attend This Event" button for event creators.

### Event Model Improvements

* Updated the `Event` model to automatically add the creator as an attendee when a new event is created.

### Documentation Updates

* Expanded the `README.md` to document the new attendance and invitation features, clarify user permissions, and list important dependencies.